### PR TITLE
Correct "verify" validation in restore input, like it is for backup.

### DIFF
--- a/bin/splunkversioncontrol_restore.py
+++ b/bin/splunkversioncontrol_restore.py
@@ -185,7 +185,15 @@ def validate_arguments():
 
     sslVerify = False
     if 'sslVerify' in val_data:
-        sslVerify = val_data['sslVerify']
+        if val_data['sslVerify'].lower() == 'true':
+            sslVerify = True
+            logger.debug('sslverify set to boolean True from: ' + val_data['sslVerify'])
+        elif val_data['sslVerify'].lower() == 'false':
+            sslVerify = False
+            logger.debug('sslverify set to boolean False from: ' + val_data['sslVerify'])
+        else:
+            sslVerify = val_data['sslVerify']
+            logger.debug('sslverify set to: ' + val_data['sslVerify'])
 
     session_key = val_data['session_key']
 
@@ -208,7 +216,7 @@ def validate_arguments():
                 proxies['https'] = proxies['https'][0:start-9] + temp_password + proxies['https'][end:]
 
         try:
-            logger.debug("Running query against URL %s with username %s proxies_length=%s" % (url, destUsername, len(proxies)))
+            logger.debug("Running query against URL %s with username %s proxies_length=%s" % (url, destUsername, len(proxies), sslVerify))
             res = requests.get(url, auth=(destUsername, destPassword), verify=sslVerify, proxies=proxies)
             logger.debug("End query against URL %s with username %s" % (url, destUsername))
             if (res.status_code != requests.codes.ok):

--- a/bin/splunkversioncontrol_restore.py
+++ b/bin/splunkversioncontrol_restore.py
@@ -52,7 +52,6 @@ SCHEME = """<scheme>
             <arg name="sslVerify">
                 <title>sslVerify</title>
                 <description>Set to 'true' or 'false' to enable/disable SSL verification for REST requests to `srcUrl`. Set to a path to specify a file with valid CA. (https://2.python-requests.org/en/master/user/advanced/#ssl-cert-verification)</description>
-                <validation>is_bool('sslVerify')</validation>
                 <required_on_create>false</required_on_create>
             </arg>
  

--- a/bin/splunkversioncontrol_restore_class.py
+++ b/bin/splunkversioncontrol_restore_class.py
@@ -951,7 +951,15 @@ class SplunkVersionControlRestore:
         self.proxies = proxies
 
         if 'sslVerify' in config:
-            self.sslVerify = config['sslVerify']
+            if config['sslVerify'].lower() == 'true':
+                self.sslVerify = True
+                logger.debug('sslverify set to boolean True from: ' + config['sslVerify'])
+            elif config['sslVerify'].lower() == 'false':
+                self.sslVerify = False
+                logger.debug('sslverify set to boolean False from: ' + config['sslVerify'])
+            else:
+                self.sslVerify = config['sslVerify']
+                logger.debug('sslverify set to: ' + config['sslVerify'])
 
         dirExists = os.path.isdir(self.gitTempDir)
         if dirExists and len(os.listdir(self.gitTempDir)) != 0:


### PR DESCRIPTION
By forcing verify to a boolean, you are unable to specify the path to a certificate file. This change brings restore inline with backup, which had the validation removed in the last version.